### PR TITLE
capdl-loader: use SEL4_BI_FRAME_SIZE

### DIFF
--- a/capdl-loader-app/src/main.c
+++ b/capdl-loader-app/src/main.c
@@ -1906,12 +1906,12 @@ static void init_copy_addr(seL4_BootInfo *bi)
      * the next 16mb alignment where we can map in a pagetable.
      */
     uintptr_t bi_start = (uintptr_t)bi;
-    copy_addr = ROUND_UP(bi_start + PAGE_SIZE_4K + bi->extraLen, 0x1000000);
+    copy_addr = ROUND_UP(bi_start + SEL4_BI_FRAME_SIZE + bi->extraLen, 0x1000000);
 }
 
 static void cache_extended_bootinfo_headers(seL4_BootInfo *bi)
 {
-    uintptr_t cur = (uintptr_t)bi + PAGE_SIZE_4K;
+    uintptr_t cur = (uintptr_t)bi + SEL4_BI_FRAME_SIZE;
     uintptr_t end = cur + bi->extraLen;
 
     while (cur < end) {


### PR DESCRIPTION
Drop hard-coding the 4 KiB assumption.

Test with: axel-h/seL4#95